### PR TITLE
Break a bone - Small change

### DIFF
--- a/RealismClient/init.client.lua
+++ b/RealismClient/init.client.lua
@@ -329,6 +329,11 @@ local function updateLookAngles(dt: number)
 				dirty = true
 			end
 
+			if not motor.Enabled then
+				dirty = false
+				continue
+			end
+
 			if dirty then
 				-- stylua: ignore
 				local cf = CFrame.Angles(0, fPitch, 0)


### PR DESCRIPTION
Script now checks if the motors are enabled before transforming them. Good addition if you transform them when motors are disabled.

I've done this small change because I am creating a "bones"-like system in which when player breaks a bone, Realism script would apply transformations on "broken" motors and ruin immersion. Now Realism script will not apply transformations on motors in such state.